### PR TITLE
fix: parameter ids types in Zotero.Items.erase

### DIFF
--- a/types/xpcom/data/dataObjects.d.ts
+++ b/types/xpcom/data/dataObjects.d.ts
@@ -256,7 +256,7 @@ declare namespace _ZoteroTypes {
      * @return {Promise}
      */
     erase(
-      ids: number,
+      ids: number|number[],
       options?: Zotero.DataObject.EraseOptions & {
         onProgress?: (progress: number, progressMax: number) => void;
       }


### PR DESCRIPTION
Update parameter `ids` to `number|number[]` in `Zotero.Items.erase`