### PR TITLE
Add missing `underline` and `text` types to Annotations

### DIFF
--- a/types/xpcom/annotations.d.ts
+++ b/types/xpcom/annotations.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace _ZoteroTypes {
   namespace Annotations {
-    type AnnotationType = "highlight" | "image" | "ink" | "note";
+    type AnnotationType = "highlight" | "image" | "ink" | "note" | "underline" | "text";
     interface AnnotationJson {
       id: string;
       text: string;
@@ -33,6 +33,9 @@ declare namespace _ZoteroTypes {
     ANNOTATION_TYPE_NOTE: 2;
     ANNOTATION_TYPE_IMAGE: 3;
     ANNOTATION_TYPE_INK: 4;
+    ANNOTATION_TYPE_UNDERLINE: 5;
+    ANNOTATION_TYPE_TEXT: 6;
+    DEFAULT_COLOR: "#ffd400";
     readonly PROPS: [
       "type",
       "authorName",


### PR DESCRIPTION
Fixes #42

See:

https://github.com/zotero/zotero/blob/main/chrome/content/zotero/xpcom/annotations.js#L35

https://github.com/zotero/zotero/blob/main/chrome/content/zotero/xpcom/data/items.js#L462