### PR TITLE
Make fields in `options` in DB query methods optional

### DIFF
--- a/types/xpcom/db.d.ts
+++ b/types/xpcom/db.d.ts
@@ -96,10 +96,10 @@ declare namespace _ZoteroTypes {
       sql: string,
       params: DB.QueryParams,
       options?: {
-        inBackup: boolean;
-        noParseParams: boolean;
-        onRow: (row: unknown, cancel: unknown) => void;
-        noCache: boolean;
+        inBackup?: boolean;
+        noParseParams?: boolean;
+        onRow?: (row: unknown, cancel: unknown) => void;
+        noCache?: boolean;
       },
     ): Promise<object[] | undefined>;
 
@@ -107,10 +107,10 @@ declare namespace _ZoteroTypes {
       sql: string,
       params: DB.QueryParams,
       options?: {
-        inBackup: boolean;
-        noParseParams: boolean;
-        onRow: (row: unknown, cancel: unknown) => void;
-        noCache: boolean;
+        inBackup?: boolean;
+        noParseParams?: boolean;
+        onRow?: (row: unknown, cancel: unknown) => void;
+        noCache?: boolean;
       },
     ): Promise<object[] | undefined>;
 
@@ -122,7 +122,7 @@ declare namespace _ZoteroTypes {
     valueQueryAsync(
       sql: string,
       params: DB.QueryParams,
-      options?: { inBackup: boolean; noCache: boolean },
+      options?: { inBackup?: boolean; noCache?: boolean },
     ): Promise<object[] | boolean>;
 
     /**
@@ -144,17 +144,17 @@ declare namespace _ZoteroTypes {
       sql: string,
       params: DB.QueryParams,
       options?: {
-        inBackup: boolean;
-        noCache: boolean;
-        debug: boolean;
-        debugParams: boolean;
+        inBackup?: boolean;
+        noCache?: boolean;
+        debug:? boolean;
+        debugParams?: boolean;
       },
     ): Promise<object[][]>;
 
     logQuery(
       sql: string,
       params?: DB.QueryParams,
-      options?: { debug: boolean; debugParams: boolean },
+      options?: { debug?: boolean; debugParams?: boolean },
     ): void;
 
     tableExists(table: string, db?: string): Promise<boolean>;


### PR DESCRIPTION
Hello! thanks for this package :)

I was noticing while doing some DB calls that I can't do this:

```ts
let rows = await Zotero.DB.queryAsync(statement, [], {
  noCache: true,
});
```

because all the fields of the options object are required:

```
npm error src/connection.ts:19:73 - error TS2345: Argument of type '{ noCache: true; }' is not assignable to parameter of type '{ inBackup: boolean; noParseParams: boolean; onRow: (row: unknown, cancel: unknown) => void; noCache: boolean; }'.
npm error   Type '{ noCache: true; }' is missing the following properties from type '{ inBackup: boolean; noParseParams: boolean; onRow: (row: unknown, cancel: unknown) => void; noCache: boolean; }': inBackup, noParseParams, onRow
npm error
npm error 19       const lastInsertRowID = await Zotero.DB.queryAsync(statement, [], {
npm error                                                                            ~
npm error 20         noCache: true,
npm error    ~~~~~~~~~~~~~~~~~~~~~~
npm error 21       });
npm error    ~~~~~~~

```

It appears that they are all in fact optional, looking at the way it is called internally in Zotero, so a minor patch to reflect that :)