### PR TITLE
Add missing function: `refreshColumns(): void;`

### DIFF
--- a/types/xpcom/pluginAPI/itemTreeManager.d.ts
+++ b/types/xpcom/pluginAPI/itemTreeManager.d.ts
@@ -185,5 +185,7 @@ declare namespace _ZoteroTypes {
      * @returns {string}
      */
     getCustomCellData(item: Zotero.Item, dataKey: string): string;
+
+    refreshColumns(): void;
   }
 }


### PR DESCRIPTION
Add the missing function according to the source code of Zotero:

https://github.com/zotero/zotero/blob/main/chrome/content/zotero/xpcom/pluginAPI/itemTreeManager.js#L340-L342