### PR TITLE
Add DBConnection class type :)

### DIFF
--- a/types/xpcom/db.d.ts
+++ b/types/xpcom/db.d.ts
@@ -235,4 +235,8 @@ declare namespace _ZoteroTypes {
 
     _debug(str: string, level?: number): void;
   }
+
+  interface DBConnection extends DB {
+    new (dbNameOrPath: string): this;
+  }
 }

--- a/types/zotero.d.ts
+++ b/types/zotero.d.ts
@@ -304,6 +304,7 @@ declare const Zotero: {
   EditorInstance: Zotero.EditorInstance;
   ProgressWindow: Zotero.ProgressWindow;
   CollectionTreeRow: Zotero.CollectionTreeRow;
+  DBConnection: _ZoteroTypes.DBConnection;
 
   Locale: {
     readonly availableLocales: _ZoteroTypes.AvailableLocales;


### PR DESCRIPTION
Apparently there is a class constructor `DBConnection` that can create objects like `Zotero.DB`: https://groups.google.com/g/zotero-dev/c/09k98DXvzZQ/m/74kWDoNSAwAJ

So this is just adding that. I'm pretty sure this is how you annotate a class with a constructor? not a typescript expert by any means