### PR TITLE
fix: return type of Zotero.Tags.getColors

### DIFF
--- a/types/xpcom/data/tags.d.ts
+++ b/types/xpcom/data/tags.d.ts
@@ -153,7 +153,7 @@ declare namespace _ZoteroTypes {
      * @return {Map} - A Map with tag names as keys and objects containing 'color' and 'position'
      *     as values
      */
-    getColors(libraryID: number): Map<string, number>;
+    getColors(libraryID: number): Map<string, { color: string; position: number }>;
 
     /**
      * Assign a color to a tag


### PR DESCRIPTION
The return type of `Zotero.Tags.getColors` was `Map<string, number>` but it should be `Map<string, { color: string; position: number }>`:

```js
    /**
     * Get colored tags within a given library
     *
     * @param {Integer} libraryID
     * @return {Map} - A Map with tag names as keys and objects containing 'color' and 'position'
     *     as values
     */
```