### PR TITLE
Fix annotationSortIndex type (string, not number)

### DIFF
--- a/types/xpcom/data/item.d.ts
+++ b/types/xpcom/data/item.d.ts
@@ -881,7 +881,7 @@ declare namespace Zotero {
     annotationPosition: string;
     annotationColor: string;
     annotationPageLabel: string;
-    annotationSortIndex: number;
+    annotationSortIndex: string;
     annotationIsExternal: boolean;
 
     isAnnotationSupportingImage(): boolean;


### PR DESCRIPTION
annotationSortIndex is currently typed as a number, but Zotero runtime appears to be using a string-based sort key of the type ("00000|000123|00456").

See, for example:
- getSortIndex() in reader/src/pdf/selection.js and lines 292-296 in zotero/test/tests/fileInterfaceTest.js
