### PR TITLE
feat(types): add UndoHistory, Zotero.ftl, and SaveOptions undo fields for Zotero 10

### DIFF
--- a/types/xpcom/data/dataObject.d.ts
+++ b/types/xpcom/data/dataObject.d.ts
@@ -35,6 +35,20 @@ declare namespace Zotero {
        */
       notifierData?: any;
 
+      /**
+       * Fluent message ID for the undo/redo menu label (e.g. 'undo-action-edit-metadata').
+       * Adding this causes the save to be recorded on the undo stack.
+       * @since Zotero 10
+       */
+      undoAction?: string;
+
+      /**
+       * Fluent message arguments for the undo/redo label (e.g. { count: 3 }).
+       * Only needed when undoAction references a message with variables.
+       * @since Zotero 10
+       */
+      undoActionArgs?: Record<string, unknown>;
+
       tx?: boolean;
     }
     interface EraseOptions {

--- a/types/xpcom/index.d.ts
+++ b/types/xpcom/index.d.ts
@@ -17,6 +17,7 @@
 /// <reference path="reader.d.ts" />
 /// <reference path="session.d.ts" />
 /// <reference path="uiProperties.d.ts" />
+/// <reference path="undoHistory.d.ts" />
 /// <reference path="uri.d.ts" />
 /// <reference path="collectionTreeRow.d.ts" />
 /// <reference path="dataDirectory.d.ts" />

--- a/types/xpcom/undoHistory.d.ts
+++ b/types/xpcom/undoHistory.d.ts
@@ -1,0 +1,87 @@
+declare namespace Zotero {
+  class UndoHistory {
+    /**
+     * Read pref `undoHistory.steps` (default 100). Steps ≤ 0 disables undo entirely.
+     */
+    static init(): void;
+    /**
+     * @return true when `_maxSteps > 0`
+     */
+    static isEnabled(): boolean;
+    /**
+     * Discard both undo and redo stacks.
+     */
+    static clear(): void;
+    /**
+     * Discard both stacks if any entry references an object in the given library.
+     */
+    static clearForLibrary(libraryID: number): void;
+    /**
+     * @return true if the undo stack has entries
+     */
+    static canUndo(): boolean;
+    /**
+     * @return true if the redo stack has entries
+     */
+    static canRedo(): boolean;
+    /**
+     * Pop and apply the top undo entry. Returns false if stale or empty.
+     */
+    static undo(): Promise<boolean>;
+    /**
+     * Pop and apply the top redo entry. Returns false if stale or empty.
+     */
+    static redo(): Promise<boolean>;
+    /**
+     * Stage an action label on the pending undo entry.
+     * Must be called inside a DB transaction. The last call in a transaction wins.
+     *
+     * @param action Fluent message ID (e.g. 'undo-action-trash')
+     * @param actionArgs Optional Fluent message arguments (e.g. { count: 3 })
+     */
+    static stageAction(
+      action: string,
+      actionArgs?: Record<string, unknown>,
+    ): void;
+    /**
+     * Stage a change record on the pending undo entry.
+     * Must be called inside a DB transaction. Records for the same object
+     * are coalesced field-by-field (first-write-wins for old, last-wins for new).
+     */
+    static stageChange(changeRecord: {
+      objectType: string;
+      id: number;
+      libraryID: number;
+      key: string;
+      fields: Record<string, { old: unknown; new: unknown }>;
+      skipDateModified?: boolean;
+    }): void;
+    /**
+     * Return the action description for the top of the undo stack.
+     */
+    static getUndoAction(): {
+      action: string;
+      actionArgs: Record<string, unknown> | null;
+    } | null;
+    /**
+     * Return the action description for the top of the redo stack.
+     */
+    static getRedoAction(): {
+      action: string;
+      actionArgs: Record<string, unknown> | null;
+    } | null;
+    /**
+     * Return a XUL controller that delegates to native text-editing
+     * controllers when they are active.
+     */
+    static getController(doc: Document): object;
+    /**
+     * Return true if a native text editor handles undo (e.g. focused input).
+     */
+    static hasNativeUndo(doc: Document): boolean;
+    /**
+     * Return true if a native text editor handles redo (e.g. focused input).
+     */
+    static hasNativeRedo(doc: Document): boolean;
+  }
+}

--- a/types/zotero.d.ts
+++ b/types/zotero.d.ts
@@ -279,6 +279,17 @@ declare namespace Zotero {
     ): "ltr" | "rtl";
   };
 
+  /**
+   * Fluent localization instance shared across the application.
+   * Register plugin FTL files with addResourceIds() to make strings
+   * available for undo labels and other global Fluent lookups.
+   * @since Zotero 10
+   */
+  const ftl: {
+    addResourceIds: (resourceIds: string[]) => void;
+    removeResourceIds: (resourceIds: string[]) => void;
+  };
+
   const Intl: {
     strings: {
       [key: string]: string;


### PR DESCRIPTION
## Summary

Add type definitions for three new Zotero 10 APIs:

### 1. `Zotero.UndoHistory` (`types/xpcom/undoHistory.d.ts` — new file)
Complete type declaration for the in-memory undo/redo stack. Includes:
- `init()`, `isEnabled()`, `clear()`, `clearForLibrary()`
- `canUndo()` / `canRedo()`, `undo()` / `redo()`
- `stageAction()` / `stageChange()` — the two-call staging protocol for undo entries
- `getUndoAction()` / `getRedoAction()` — UI label helpers
- `getController()`, `hasNativeUndo()` / `hasNativeRedo()` — window command integration

### 2. `Zotero.ftl` (`types/zotero.d.ts`)
Fluent Localization instance shared across the application. Plugins call `addResourceIds()`/`removeResourceIds()` to register their FTL files for undo-label resolution.

### 3. `SaveOptions.undoAction` / `undoActionArgs` (`types/xpcom/data/dataObject.d.ts`)
New properties on `DataObject.SaveOptions` for the undo/redo system:
- `undoAction` — Fluent message ID for the menu label
- `undoActionArgs` — optional Fluent message arguments (e.g. `{ count: 3 }`)

### References
- [Zotero 10 for Developers — Undo/redo](https://www.zotero.org/support/dev/zotero_10_for_developers#undoredo)
- Zotero source: `chrome/content/zotero/xpcom/undoHistory.js`

All methods are declared as `static` on `Zotero.UndoHistory` class, matching the actual singleton implementation.