### PR TITLE
feat(types): update more types for Zotero 10

### DIFF
--- a/types/collectionTree.d.ts
+++ b/types/collectionTree.d.ts
@@ -10,5 +10,44 @@ declare namespace _ZoteroTypes {
      * @return {TreeRow}
      */
     getRow(index: number): Zotero.CollectionTreeRow;
+
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getSelectedLibraryIDs} instead.
+     */
+    getSelectedLibraryID(): never;
+
+    /**
+     * Return the libraryID of every selected row, in tree order
+     *
+     * @return {Integer[]}
+     */
+    getSelectedLibraryIDs(): number[];
+
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getSelectedCollections} instead.
+     */
+    getSelectedCollection(asID?: boolean): never;
+
+    /** Selected collections, safe for any selection (Zotero 10+) */
+    getSelectedCollections(asID?: false): Zotero.Collection[];
+    getSelectedCollections(asID: true): number[];
+
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getSelectedSearches} instead.
+     */
+    getSelectedSearch(asID?: boolean): never;
+
+    /** Selected saved searches, safe for any selection (Zotero 10+) */
+    getSelectedSearches(asID?: false): Zotero.Search[];
+    getSelectedSearches(asID: true): number[];
+
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Filter {@link LibraryTree.getSelectedRows} by `isGroup()` instead.
+     */
+    getSelectedGroup(asID?: boolean): never;
   }
 }

--- a/types/elements/itemPane.d.ts
+++ b/types/elements/itemPane.d.ts
@@ -4,7 +4,10 @@
 declare namespace _ZoteroTypes {
   class ItemPane extends XULElementBase {
     get content(): DocumentFragment;
-    collectionTreeRow: _ZoteroTypes.CollectionTree;
+    /** @deprecated Removed in Zotero 10 — use `collectionTreeRows` */
+    collectionTreeRow?: never;
+    /** Selected collection tree rows, in selection order (Zotero 10+) */
+    collectionTreeRows: Zotero.CollectionTreeRow[];
     itemsView: any;
     editable: boolean;
     mode: "message" | "item" | "note" | "duplicates";

--- a/types/itemTree.d.ts
+++ b/types/itemTree.d.ts
@@ -1,13 +1,116 @@
 /// <reference path="libraryTree.d.ts" />
 /// <reference path="xpcom/data/item.d.ts" />
+/// <reference path="xpcom/collectionTreeRow.d.ts" />
 
 declare namespace _ZoteroTypes {
+  namespace ItemTree {
+    /**
+     * The kind of view a set of collection tree rows adds up to.
+     * Library roots, collections, and saved searches all map to 'default'.
+     */
+    type ViewMode =
+      | "default"
+      | "trash"
+      | "duplicates"
+      | "unfiled"
+      | "retracted"
+      | "recentlyRead"
+      | "publications"
+      | "bucket"
+      | "feed"
+      | "feeds";
+  }
+
   interface ItemTree extends LibraryTree {
     [attr: string]: any;
+
+    /**
+     * @deprecated Removed in Zotero 10 — reading it returns `undefined`.
+     *     Use {@link viewMode} for view checks
+     *     (e.g. `itemsView.viewMode == 'trash'`) and
+     *     {@link collectionTreeRows} for the selected rows.
+     */
+    collectionTreeRow?: never;
+
+    /**
+     * The kind of view the selected rows add up to, for the behaviors that
+     * belong to the view rather than to any one row (trash restoring,
+     * duplicate sets, feed dates).
+     *
+     * Anything that varies between rows -- ref, libraryID, collection vs.
+     * saved search -- has to be read from collectionTreeRows instead.
+     *
+     * Zotero 10+
+     */
+    get viewMode(): ItemTree.ViewMode;
+
+    /**
+     * Selected collection tree rows backing this view, in selection order.
+     * Trees not backed by a collection tree selection (e.g. the citation
+     * explorer's) return an empty array. (Zotero 10+)
+     */
+    get collectionTreeRows(): Zotero.CollectionTreeRow[];
+
+    /**
+     * Returns an array of items of visible items in current sort order.
+     * Library header and spacer rows are filtered out automatically.
+     *
+     * @param {Boolean} asIDs - Return itemIDs
+     * @return {Zotero.Item[]|Integer[]} - An array of Zotero.Item objects or itemIDs
+     */
+    getSortedItems(asIDs?: false): Zotero.Item[];
+    getSortedItems(asIDs: true): number[];
+
+    /**
+     * Number of visible rows representing objects, excluding library headers
+     * and spacers (Zotero 10+)
+     */
+    get objectRowCount(): number;
+
+    getRow(index: number): ItemTreeRow;
+  }
+
+  /**
+   * Item tree rendering the items of the collection tree selection.
+   * `ZoteroPane.itemsView` is an instance of this class. (Zotero 10+)
+   */
+  interface CollectionViewItemTree extends ItemTree {
+    isFeedsOrFeed(): boolean;
+    get visibilityGroup(): "feed" | "feeds" | "default" | string;
+    get viewType(): string;
+    get isSortable(): boolean;
+
+    /** Compatibility wrapper around {@link changeCollectionTreeRows} */
+    changeCollectionTreeRow(
+      collectionTreeRow: Zotero.CollectionTreeRow | null | false,
+    ): Promise<void>;
+    changeCollectionTreeRows(
+      collectionTreeRows: Zotero.CollectionTreeRow[] | false,
+    ): Promise<void>;
+
+    /** Collection-aware delete (moved from ItemTree in Zotero 10) */
+    deleteSelection(force?: boolean): Promise<void>;
   }
 
   interface ItemTreeRow extends TreeRow {
-    new (ref: Zotero.DataObject, level: number, isOpen: boolean): this;
+    new (
+      ref: Zotero.DataObject,
+      level: number,
+      isOpen: boolean,
+      id?: string,
+    ): this;
+
+    /**
+     * Whether the row represents an object in the view, as opposed to a
+     * library header or spacer. Callers that operate on the view's contents
+     * (counting rows, collecting items, walking top-level rows) should skip
+     * rows where this is false. (Zotero 10+)
+     */
+    get isObjectRow(): boolean;
+
+    /** 'item' for object rows; 'library-header' / 'spacer' otherwise (Zotero 10+) */
+    get type(): "item" | "library-header" | "spacer" | string;
+
     getField(
       field: _ZoteroTypes.Item.ItemField | number,
       unformatted?: boolean,

--- a/types/libraryTree.d.ts
+++ b/types/libraryTree.d.ts
@@ -80,5 +80,17 @@ declare namespace _ZoteroTypes {
     setDropEffect(event: unknown, effect: unknown): void;
 
     selectLibrary(libraryID?: number): Promise<boolean>;
+
+    /**
+     * Get selected tree rows
+     *
+     * @return {TreeRow[]}
+     */
+    getSelectedRows(): TreeRow[];
+
+    /**
+     * Get the `ref` of every selected tree row
+     */
+    getSelectedObjects(): unknown[];
   }
 }

--- a/types/xpcom/attachments.d.ts
+++ b/types/xpcom/attachments.d.ts
@@ -128,7 +128,6 @@ declare namespace _ZoteroTypes {
      * @param {Boolean} [options.renameIfAllowedType=false]
      * @param {String} [options.contentType]
      * @param {String} [options.referrer]
-     * @param {CookieSandbox} [options.cookieSandbox]
      * @param {Object} [options.saveOptions] - Options to pass to Zotero.Item::save()
      * @return {Promise<Zotero.Item>} - A promise for the created attachment item
      */
@@ -201,26 +200,24 @@ declare namespace _ZoteroTypes {
      * @param {String} url
      * @param {String} path
      * @param {Object} [options]
-     * @param {Object} [options.cookieSandbox]
      * @param {String} [options.referrer]
      * @param {Boolean} [options.isPDF] - Delete file if not PDF
      */
     downloadFile(
       url: string,
       path: string,
-      options?: { cookieSandbox?: object; referrer?: string },
+      options?: { referrer?: string; isPDF?: boolean },
     ): Promise<boolean>;
 
     /**
      * @param {String} url
      * @param {String} path
      * @param {Object} [options]
-     * @param {Object} [options.cookieSandbox]
      */
     downloadPDFViaBrowser(
       url: string,
       path: string,
-      options?: { cookieSandbox?: object },
+      options?: object,
     ): Promise<boolean>;
 
     InvalidPDFException: typeof Error & {

--- a/types/xpcom/collectionTreeRow.d.ts
+++ b/types/xpcom/collectionTreeRow.d.ts
@@ -20,34 +20,77 @@ declare namespace Zotero {
     isSearch(): boolean;
     isDuplicates(): boolean;
     isUnfiled(): boolean;
+    /** Zotero 10+ */
+    isRecentlyRead(): boolean;
     isRetracted(): boolean;
     isTrash(): boolean;
     isHeader(): boolean;
     isPublications(): boolean;
     isGroup(): boolean;
     isFeed(): boolean;
+    /** Zotero 10+ */
+    isFeeds(): boolean;
+    /** Zotero 10+ */
+    isFeedsOrFeed(): boolean;
     isSeparator(): boolean;
     isBucket(): boolean;
     isShare(): boolean;
     isContainer(): boolean;
     isWithinGroup(): boolean;
     isWithinEditableGroup(): boolean;
+    /** Zotero 10+ */
+    isSortable(): boolean;
 
     get editable(): boolean;
     get filesEditable(): boolean;
     get visibilityGroup(): "feed" | "feeds" | "default";
     getName(): string;
     getChildren(): Zotero.Collection | Zotero.Feed | undefined;
-    getItems(): Promise<Array<Item | unknown>>; //
-    getSearchResults(asTempTable?: false): Promise<number[]>;
-    getSearchResults(asTempTable: true): Promise<string>;
+
+    /**
+     * Trashed collections in this row's library (Trash rows only, Zotero 10+)
+     */
+    getTrashedCollections(): Promise<Zotero.Collection[]>;
+
+    /**
+     * @param {Object} [options]
+     * @param {Boolean} [options.unfiltered=false] - If true, ignore quicksearch, tag, and
+     *     advanced search filters
+     */
+    getItems(options?: {
+      unfiltered?: boolean;
+    }): Promise<Array<Item | unknown>>; //
+
+    /**
+     * @param {Boolean} [asTempTable=false]
+     * @param {Object} [options]
+     * @param {Boolean} [options.unfiltered=false] - If true, ignore quicksearch, tag, and
+     *     advanced search filters and bypass the cache
+     */
+    getSearchResults(
+      asTempTable?: false,
+      options?: { unfiltered?: boolean },
+    ): Promise<number[]>;
+    getSearchResults(
+      asTempTable: true,
+      options?: { unfiltered?: boolean },
+    ): Promise<string>;
 
     /*
      * Returns the search object for the currently display
      *
      * This accounts for the collection, saved search, quicksearch, tags, etc.
+     *
+     * @param {Object} [options]
+     * @param {Boolean} [options.unfiltered=false] - If true, ignore quicksearch, tag, and
+     *     advanced search filters and bypass the cache
      */
-    getSearchObject(): Promise<Zotero.Search>;
+    getSearchObject(options?: { unfiltered?: boolean }): Promise<Zotero.Search>;
+
+    /**
+     * @deprecated Use getTags() instead
+     */
+    getChildTags(): Promise<_ZoteroTypes.Tags.TagJson[]>;
 
     /**
      * Returns all the tags used by items in the current view

--- a/types/xpcom/cookieSandbox.d.ts
+++ b/types/xpcom/cookieSandbox.d.ts
@@ -1,13 +1,32 @@
+declare namespace _ZoteroTypes {
+  /**
+   * An isolated cookie context backed by a unique Mozilla userContextId,
+   * created with {@link Zotero.HTTP.newCookieContext} (Zotero 10+).
+   *
+   * All HTTP requests and HiddenBrowsers that share the same context ID will
+   * share a separate cookie jar, isolated from the default jar and from other
+   * contexts. Call dispose() when finished to remove all cookies in the
+   * context.
+   *
+   * @example
+   * ```js
+   * let cookieContext = Zotero.HTTP.newCookieContext();
+   * await Zotero.HTTP.request('GET', url, { userContextId: cookieContext.id });
+   * let cookies = cookieContext.getCookies('example.com');
+   * cookieContext.dispose();
+   * ```
+   */
+  interface CookieContext {
+    id: number;
+    getCookies(host: string): nsICookie[];
+    dispose(): void;
+  }
+}
+
 declare namespace Zotero {
   /**
-   * Manage cookies in a sandboxed fashion
-   *
-   * @constructor
-   * @param {browser} [browser] Hidden browser object
-   * @param {String|nsIURI} uri URI of page to manage cookies for (cookies for domains that are not
-   *                     subdomains of this URI are ignored)
-   * @param {String} cookieData Cookies with which to initiate the sandbox
-   * @param {String} userAgent User agent to use for sandboxed requests
+   * @deprecated Removed in Zotero 10 — use {@link Zotero.HTTP.newCookieContext}
+   *     and pass its numeric `id` as the `userContextId` request option.
    */
   interface CookieSandbox {
     new (
@@ -16,26 +35,5 @@ declare namespace Zotero {
       cookieData: string,
       userAgent: string,
     ): this;
-
-    /**
-     * Normalizes the host string: lower-case, remove leading period, some more cleanup
-     * @param {string} host
-     * @returns {string}
-     */
-    normalizeHost(host: string): string;
-
-    /**
-     * Normalizes the path string
-     * @param {string} path
-     * @returns {string}
-     */
-    normalizePath(path: string): string;
-
-    /**
-     * Generates a semicolon-separated string of cookie values from a list of cookies
-     * @param {Object} cookies Object containing key: value cookie pairs
-     * @returns {string}
-     */
-    generateCookieString(cookies: { [key: string]: string }): string;
   }
 }

--- a/types/xpcom/data/dataObject.d.ts
+++ b/types/xpcom/data/dataObject.d.ts
@@ -40,7 +40,7 @@ declare namespace Zotero {
        * Adding this causes the save to be recorded on the undo stack.
        * @since Zotero 10
        */
-      undoAction?: string;
+      undoAction?: _ZoteroTypes.UndoHistory.UndoAction;
 
       /**
        * Fluent message arguments for the undo/redo label (e.g. { count: 3 }).

--- a/types/xpcom/data/item.d.ts
+++ b/types/xpcom/data/item.d.ts
@@ -469,6 +469,9 @@ declare namespace Zotero {
 
     /*
      * Set or change the item's type
+     *
+     * Since Zotero 10, changing between regular items, attachments, notes,
+     * and annotations throws an error.
      */
     setType(itemTypeID: number, loadIn?: boolean): boolean;
 
@@ -746,6 +749,9 @@ declare namespace Zotero {
      *
      * This will return the filename for all file attachments, but the filename can only be set
      * for stored file attachments. Linked file attachments should be set using .attachmentPath.
+     *
+     * Since Zotero 10, the setter throws if the value contains a directory
+     * path — it must be a bare filename.
      */
     attachmentFilename: string;
 
@@ -754,6 +760,10 @@ declare namespace Zotero {
      * (e.g., "storage:foo.pdf", "attachments:foo/bar.pdf", "/Users/foo/Desktop/bar.pdf")
      *
      * Can be set as absolute path or prefixed string ("storage:foo.pdf")
+     *
+     * Since Zotero 10, the setter throws for stored-file attachments if the
+     * part after the `storage:` prefix contains a directory path — it must
+     * be a bare filename.
      */
     attachmentPath: string;
 

--- a/types/xpcom/data/search.d.ts
+++ b/types/xpcom/data/search.d.ts
@@ -30,19 +30,47 @@ declare namespace Zotero {
 
     _eraseData(env: _ZoteroTypes.Search.EnvType): Promise<void>;
 
+    /**
+     * Add a condition to the search
+     *
+     * Searches can use complex boolean logic by nesting conditions between
+     * `groupStart`/`groupEnd` conditions, with a `joinMode` condition inside
+     * the group:
+     * ```js
+     * search.addCondition('joinMode', 'all');
+     * search.addCondition('title', 'contains', 'foo');
+     * search.addCondition('groupStart', 'true', '');
+     * search.addCondition('joinMode', 'any');
+     * search.addCondition('tag', 'is', 'x');
+     * search.addCondition('tag', 'is', 'y');
+     * search.addCondition('groupEnd', 'true', '');
+     * ```
+     *
+     * The `resultLevel` condition specifies what the search returns:
+     * `item`, `attachment`, `note`, or `annotation` (passed as the operator).
+     *
+     * Note: passing a truthy legacy `required` fourth parameter throws in
+     * Zotero 10 — use a condition group instead.
+     */
+    addCondition(
+      condition: "resultLevel",
+      operator: _ZoteroTypes.Search.ResultLevel,
+    ): number;
     addCondition(
       condition: _ZoteroTypes.Search.Conditions,
       operator: _ZoteroTypes.Search.Operator,
-      value: string | number,
-      required?: boolean,
+      value?: string | number,
+      required?: false,
     ): number;
     addCondition(
       condition: string,
       operator: _ZoteroTypes.Search.Operator,
       value?: string | number,
-      required?: boolean,
+      required?: false,
     ): number;
-    addCondition(condition: "blockStart" | "blockEnd"): number;
+    addCondition(condition: "groupStart" | "groupEnd"): number;
+    /** @deprecated Renamed to `groupStart`/`groupEnd` in Zotero 10 */
+    addCondition(condition: "blockStart" | "blockEnd"): never;
 
     /**
      * Sets scope of search to the results of the passed Search object
@@ -54,15 +82,17 @@ declare namespace Zotero {
      * @param {String} condition
      * @param {String} operator
      * @param {String} value
-     * @param {Boolean} [required]
      * @return {Promise}
+     *
+     * Note: passing a truthy legacy `required` fifth parameter throws in
+     * Zotero 10 — use a condition group instead.
      */
     updateCondition(
       searchConditionID: number,
       condition: string,
       operator: string,
       value: string,
-      required: boolean,
+      required?: false,
     ): void;
 
     removeCondition(searchConditionID: number): void;
@@ -102,6 +132,14 @@ declare namespace Zotero {
     fromJSON(json: object, options?: { strict: boolean }): void;
 
     toJSON(option: object): object;
+
+    /**
+     * Copy the passed itemIDs to a temp table and return the table name
+     */
+    static idsToTempTable(
+      ids: number[],
+      options?: { idColumn?: string },
+    ): Promise<string>;
   }
 }
 
@@ -121,19 +159,24 @@ declare namespace _ZoteroTypes {
       transactionOptions: object;
       isNew: boolean;
     };
+    /**
+     * What a search returns; passed as the operator of a `resultLevel`
+     * condition (Zotero 10+)
+     */
+    type ResultLevel = "item" | "attachment" | "note" | "annotation";
     type Operator =
       | "is"
       | "isNot"
-      | "true"
-      | "false"
-      | "isInTheLast"
-      | "isBefore"
-      | "isAfter"
+      | "beginsWith"
       | "contains"
       | "doesNotContain"
-      | "beginsWith"
       | "isLessThan"
       | "isGreaterThan"
+      | "isBefore"
+      | "isAfter"
+      | "isInTheLast"
+      | "isEmpty"
+      | "isNotEmpty"
       | "any"
       | "all"
       | "true"
@@ -155,7 +198,6 @@ declare namespace _ZoteroTypes {
       | "authority"
       | "bookAuthor"
       | "callNumber"
-      | "childNote"
       | "citationKey"
       | "code"
       | "codeNumber"
@@ -212,6 +254,7 @@ declare namespace _ZoteroTypes {
       | "versionNumber"
       | "volume"
       | "deleted"
+      | "includeDeleted"
       | "noChildren"
       | "unfiled"
       | "retracted"
@@ -227,16 +270,26 @@ declare namespace _ZoteroTypes {
       | "quicksearch-fields"
       | "quicksearch-everything"
       | "quicksearch"
-      | "blockStart"
-      | "blockEnd"
+      | "groupStart"
+      | "groupEnd"
+      | "resultLevel"
       | "collectionID"
       | "savedSearchID"
       | "savedSearch"
+      | "lastRead"
       | "itemTypeID"
+      | "attachmentStorageType"
       | "tagID"
+      | "numTags"
+      | "numNotes"
+      | "numAttachments"
+      | "numAnnotations"
       | "lastName"
+      | "titleCreatorYear"
       | "field"
       | "datefield"
+      | "dateDue"
+      | "accepted"
       | "year"
       | "numberfield"
       | "libraryID"
@@ -244,7 +297,9 @@ declare namespace _ZoteroTypes {
       | "itemID"
       | "annotationText"
       | "annotationComment"
-      | "fulltextWord"
+      | "annotationType"
+      | "annotationColor"
+      | "annotationAuthor"
       | "tempTable";
   }
 }

--- a/types/xpcom/db.d.ts
+++ b/types/xpcom/db.d.ts
@@ -213,6 +213,37 @@ declare namespace _ZoteroTypes {
      */
     escapeSQLExpression(expr: string): string;
 
+    /**
+     * Load a bundled SQLite extension (e.g., 'fts5') on the connection.
+     *
+     * Mozilla's mozStorage doesn't compile FTS in by default and disables generic extension
+     * loading, but it does allow loading specific bundled extensions by name. The module is
+     * registered per connection, so call this once: the extension is remembered and re-loaded
+     * automatically when the connection is reopened (e.g., after a vacuum()), before onConnect()
+     * callbacks run, so callers don't have to reload it themselves.
+     *
+     * @since Zotero 10
+     */
+    loadExtension(name: string): Promise<unknown>;
+
+    /**
+     * Register a callback to run when a corruption error occurs but the main database checks out,
+     * meaning an attached database (e.g., the rebuildable full-text index) is corrupt. The
+     * callback can rebuild it. Run deferred, after the failing operation unwinds.
+     *
+     * @since Zotero 10
+     */
+    addCorruptionHandler(handler: () => void | Promise<void>): void;
+
+    /**
+     * Register a callback to run during the database's idle maintenance, after the periodic
+     * backup and vacuum. Lets code with its own attached database do maintenance (e.g.,
+     * vacuuming) on the same idle trigger.
+     *
+     * @since Zotero 10
+     */
+    onIdle(callback: () => void | Promise<void>): void;
+
     /////////////////////////////////////////////////////////////////
     //
     // Private methods

--- a/types/xpcom/fulltext.d.ts
+++ b/types/xpcom/fulltext.d.ts
@@ -27,30 +27,6 @@ declare namespace _ZoteroTypes {
     setItemSynced(itemID: number, version: number): Promise<void>;
     getPDFConverterExecAndArgs(): { exec: string; args: string[] };
     isCachedMIMEType(mimeType: string): boolean;
-    indexItems(
-      itemIDs: number[],
-      options?: { complete?: boolean; ignoreErrors?: boolean },
-    ): Promise<void>;
-    rebuildIndex(unindexedOnly: boolean): Promise<void>;
-    clearIndex(skipLinkedURLs?: boolean): Promise<void>;
-    purgeUnusedWords(): Promise<void>;
-    canIndex(item: Zotero.Item): boolean;
-    canReindex(item: Zotero.Item): Promise<boolean>;
-    getIndexedState(item: Zotero.Item): Promise<number>;
-    isFullyIndexed(item: Zotero.Item): Promise<boolean>;
-    getIndexStats(): Promise<{
-      indexed: number;
-      partial: number;
-      unindexed: number;
-      words: number;
-    }>;
-    getItemCacheFile(item: Zotero.Item): nsIFile;
-    getItemProcessorCacheFile(item: Zotero.Item): nsIFile;
-    transferItemIndex(
-      fromItem: Zotero.Item,
-      toItem: Zotero.Item,
-    ): Promise<void>;
-    getPages(itemID: number): Promise<false | { total: number }>;
     indexDocument(document: Document, itemID: number): Promise<boolean | void>;
     indexPDF(
       filePath: string,
@@ -62,13 +38,170 @@ declare namespace _ZoteroTypes {
       itemID: number,
       allText?: boolean,
     ): Promise<boolean>;
+
+    /**
+     * @param {Integer[]|Integer} itemIDs - One or more itemIDs
+     * @param {Object} [options]
+     * @param {Boolean} [options.complete=false] - Ignore page/character limits
+     * @param {Boolean} [options.ignoreErrors=false] - Continue on error instead of throwing
+     */
     indexItems(
       itemIDs: number | number[],
       options?: { complete?: boolean; ignoreErrors?: boolean },
     ): Promise<void>;
-    indexFromProcessorCache(itemID: number): Promise<boolean>;
-    clearItemWords(itemID: number, force?: boolean): Promise<void>;
+
+    queueItem(item: Zotero.Item): Promise<void>;
+    getUnsyncedContent(libraryID: number, options?: object): Promise<object[]>;
+    getUndownloadedPostData(): Promise<string | null>;
+    setItemContent(
+      libraryID: number,
+      key: string,
+      data: object | string,
+      version: number,
+    ): Promise<void>;
+
+    /** Zotero 10+ (renamed from registerContentProcessor()) */
+    registerSyncContentProcessor(): void;
+    /** Zotero 10+ (renamed from unregisterContentProcessor()) */
+    unregisterSyncContentProcessor(): void;
+    /** Zotero 10+ (renamed from stopContentProcessor()) */
+    stopSyncContentProcessor(): void;
+    /** Zotero 10+ (renamed from processUnprocessedContent()) */
+    processSyncedContent(itemIDs: number[]): Promise<void>;
+    /** Zotero 10+ */
+    processSyncedContentNow(): Promise<void>;
+    indexSyncedContent(itemID: number): Promise<void>;
+
+    /** @return {Promise<Integer>} (Zotero 10+) */
+    getAttachmentIndexQueueCount(): Promise<number>;
+    /**
+     * @return {Promise<Integer>} The number of items processed (Zotero 10+)
+     */
+    processAttachmentIndexQueue(options?: {
+      maxTime?: number | null;
+      checkIdle?: boolean;
+      onProgress?: Function | null;
+    }): Promise<number>;
+    /** @return {Promise<Integer>} (Zotero 10+) */
+    getAttachmentExtractionQueueCount(): Promise<number>;
+    /**
+     * @return {Promise<Integer>} The number of items processed (Zotero 10+)
+     */
+    processAttachmentExtractionQueue(options?: {
+      maxTime?: number | null;
+      checkIdle?: boolean;
+    }): Promise<number>;
+    /** @return {Promise<Integer>} (Zotero 10+) */
+    getNoteIndexQueueCount(): Promise<number>;
+    /**
+     * @return {Promise<Integer>} The number of notes processed (Zotero 10+)
+     */
+    processNoteIndexQueue(options?: {
+      maxTime?: number | null;
+      checkIdle?: boolean;
+      onProgress?: Function | null;
+    }): Promise<number>;
+    /** Zotero 10+ */
+    startQueueDrain(): Promise<void>;
+    /** Zotero 10+ */
+    optimizeContentIndex(): Promise<void>;
+    /**
+     * @return {Promise<Boolean>} - Whether the index was vacuumed (Zotero 10+)
+     */
+    vacuumContentIndex(options?: { force?: boolean }): Promise<boolean>;
+    /** Zotero 10+ */
+    registerQueueDrainObserver(): void;
+    /** Zotero 10+ */
+    unregisterQueueDrainObserver(): void;
+
+    /**
+     * @param {Number} itemID
+     * @param {String} note - The note's HTML (Zotero 10+)
+     */
+    flagNoteStale(itemID: number, note: string): Promise<void>;
+    /** Zotero 10+ */
+    clearNoteIndex(itemID: number): Promise<void>;
+
+    /** Zotero 10+ */
+    canSearchContent(searchText: string): boolean;
+    /** Zotero 10+ */
+    canSearchNotes(searchText: string): boolean;
+    /**
+     * @return {Promise<Object|null>} { sql, params }, or null to fall back
+     *     to a raw scan (Zotero 10+)
+     */
+    getNoteContentSQL(
+      searchText: string,
+    ): Promise<{ sql: string; params: unknown[] } | null>;
+    /**
+     * @param {String} searchText
+     * @param {Integer|null} [libraryID] - Restrict to this library, or null/undefined for all
+     * @param {Integer[]|null} [scopeIDs] - Restrict to these items
+     * @return {Promise<Integer[]|null>} (Zotero 10+)
+     */
+    findItemsWithContent(
+      searchText: string,
+      libraryID?: number | null,
+      scopeIDs?: number[] | null,
+    ): Promise<number[] | null>;
+    /** @return {Object|null} { sql, params } (Zotero 10+) */
+    getContentSearchSQL(
+      searchText: string,
+    ): { sql: string; params: unknown[] } | null;
+    findTextInItems(
+      items: number[],
+      searchText: string,
+      mode?: string,
+    ): Promise<Array<{ id: number; match: object }>>;
+
+    transferItemIndex(
+      fromItem: Zotero.Item,
+      toItem: Zotero.Item,
+    ): Promise<void>;
+    clearItemWords(itemID: number, skipCacheClear?: boolean): Promise<void>;
+    getPages(itemID: number): Promise<false | { total: number }>;
+    getIndexedState(item: Zotero.Item): Promise<number>;
+    isFullyIndexed(item: Zotero.Item): Promise<boolean>;
+    getIndexStats(): Promise<{
+      indexed: number;
+      partial: number;
+      notAvailable: number;
+      notesIndexed: number;
+      remaining: number;
+      unindexedQueue: number;
+      noteQueue: number;
+    }>;
+    getItemCacheFile(item: Zotero.Item): nsIFile;
+    /** Zotero 10+ (renamed from getItemProcessorCacheFile()) */
+    getSyncedContentCacheFile(item: Zotero.Item): nsIFile;
+    canIndex(item: Zotero.Item): boolean;
+    canReindex(item: Zotero.Item): Promise<boolean>;
+    rebuildIndex(unindexedOnly?: boolean): Promise<void>;
+    /**
+     * @param {String} type - 'chars' or 'pages'
+     * @param {Integer} newLimit (Zotero 10+)
+     */
+    reindexTruncated(type: "chars" | "pages", newLimit: number): Promise<void>;
+    /** Zotero 10+ */
+    purgeOrphanedContent(): Promise<void>;
     semanticSplitter(text: string, charset?: string): string[];
+
+    /** @deprecated Removed in Zotero 10 */
+    clearIndex(skipLinkedURLs?: boolean): never;
+    /** @deprecated Removed in Zotero 10 */
+    purgeUnusedWords(): never;
+    /** @deprecated Removed in Zotero 10 — use getSyncedContentCacheFile() */
+    getItemProcessorCacheFile(item: Zotero.Item): never;
+    /** @deprecated Removed in Zotero 10 */
+    indexFromProcessorCache(itemID: number): never;
+    /** @deprecated Removed in Zotero 10 — use registerSyncContentProcessor() */
+    registerContentProcessor(): never;
+    /** @deprecated Removed in Zotero 10 — use unregisterSyncContentProcessor() */
+    unregisterContentProcessor(): never;
+    /** @deprecated Removed in Zotero 10 — use stopSyncContentProcessor() */
+    stopContentProcessor(): never;
+    /** @deprecated Removed in Zotero 10 — use processSyncedContent() */
+    processUnprocessedContent(itemIDs: number[]): never;
   }
 }
 declare namespace Zotero {

--- a/types/xpcom/http.d.ts
+++ b/types/xpcom/http.d.ts
@@ -16,8 +16,8 @@ declare namespace _ZoteroTypes {
      * @param {Object | Headers} [options.headers] - HTTP headers to send with the request
      * @param {Boolean} [options.followRedirects = true] - Object of HTTP headers to send with the
      *     request
-     * @param {Zotero.CookieSandbox} [options.cookieSandbox] - The sandbox from which cookies should
-     *     be taken
+     * @param {Boolean} [options.anon] - Make the request anonymously, without global cookies
+     * @param {Number} [options.userContextId] - From newCookieContext() for cookie isolation
      * @param {Boolean} [options.debug] - Log response text and status code
      * @param {Boolean} [options.noCache] - If set, specifies that the request should not be
      *     fulfilled from the cache
@@ -33,7 +33,6 @@ declare namespace _ZoteroTypes {
      * @param {String} [options.responseCharset] - The charset the response should be interpreted as
      * @param {Number[]|false} [options.successCodes] - HTTP status codes that are considered
      *     successful, or FALSE to allow all
-     * @param {Zotero.CookieSandbox} [options.cookieSandbox] - Cookie sandbox object
      * @param {Number} [options.timeout = 30000] - Request timeout specified in milliseconds, or 0
      *     for no timeout
      * @param {Number[]} [options.errorDelayIntervals] - Array of milliseconds to wait before
@@ -51,7 +50,17 @@ declare namespace _ZoteroTypes {
         body?: string | Uint8Array;
         headers?: any;
         followRedirects?: boolean;
-        cookieSandbox?: Zotero.CookieSandbox;
+        anon?: boolean;
+        /**
+         * From {@link newCookieContext} for cookie isolation (Zotero 10+)
+         */
+        userContextId?: number;
+        /**
+         * @deprecated Since Zotero 10 this is only a compatibility alias for
+         *     `userContextId` and must be a number; `Zotero.CookieSandbox`
+         *     objects no longer exist.
+         */
+        cookieSandbox?: number;
         debug?: boolean;
         noCache?: boolean;
         dontCache?: boolean;
@@ -69,12 +78,61 @@ declare namespace _ZoteroTypes {
     ): Promise<XMLHttpRequest>;
 
     /**
+     * Create an isolated cookie context backed by a unique Mozilla userContextId.
+     *
+     * All HTTP requests and HiddenBrowsers that share the same context ID will
+     * share a separate cookie jar, isolated from the default jar and from other
+     * contexts. Call dispose() when finished to remove all cookies in the context.
+     *
+     * @return {{ id: number, getCookies: (host: string) => nsICookie[], dispose: () => void }}
+     * @since Zotero 10
+     */
+    newCookieContext(): _ZoteroTypes.CookieContext;
+
+    /**
+     * Download a file, streaming the response body directly to disk
+     *
+     * Uses fetch() + ReadableStream instead of XMLHttpRequest so that the response body is
+     * streamed to disk chunk by chunk, avoiding the 2 GB IOUtils.write() limit and reducing
+     * memory pressure for large files.
+     *
+     * @param {nsIURI|String} uri - URL to request
+     * @param {String} path - Path to save file to
+     * @param {Object} [options]
+     * @param {Object|Headers} [options.headers] - HTTP headers to send with the request
+     * @param {Boolean} [options.noCache] - Bypass the cache
+     * @param {Number[]|false} [options.successCodes] - HTTP status codes that are considered
+     *     successful, or FALSE to allow all
+     * @param {Function} [options.onProgress] - Progress callback (totalBytes, contentLength)
+     * @param {Function} [options.cancellerReceiver] - Callback to receive a cancel function
+     * @param {Number} [options.timeout = 30000] - Timeout in milliseconds (connect and
+     *     inactivity); 0 to disable
+     * @param {Number[]} [options.errorDelayIntervals] - Retry delay intervals for 5xx errors
+     * @param {Number} [options.errorDelayMax] - Max time to spend retrying 5xx errors
+     * @return {Promise<Response>} - A promise for a fetch Response object
+     */
+    download(
+      uri: string | URL | nsIURI,
+      path: string,
+      options?: {
+        headers?: Record<string, string> | Headers;
+        noCache?: boolean;
+        successCodes?: number[] | false;
+        onProgress?: (totalBytes: number, contentLength: number) => void;
+        cancellerReceiver?: (cancel: () => void) => void;
+        timeout?: number;
+        errorDelayIntervals?: number[];
+        errorDelayMax?: number;
+      },
+    ): Promise<Response>;
+
+    /**
      * Send an HTTP GET request via XMLHTTPRequest
      *
      * @param {nsIURI|String}	url				URL to request
      * @param {Function} 		onDone			Callback to be executed upon request completion
      * @param {String} 		responseCharset	Character set to force on the response
-     * @param {Zotero.CookieSandbox} [cookieSandbox] Cookie sandbox object
+     * @param {unknown} [cookieSandbox] Ignored since Zotero 10
      * @param {Object} requestHeaders HTTP headers to include with request
      * @return {XMLHttpRequest} The XMLHttpRequest object if the request was sent, or
      *     false if the browser is offline
@@ -83,8 +141,8 @@ declare namespace _ZoteroTypes {
     doGet(
       url: string | URL,
       onDone: (xhr: XMLHttpRequest) => void | Promise<void>,
-      responseCharset: string,
-      cookieSandbox?: Zotero.CookieSandbox,
+      responseCharset?: string,
+      cookieSandbox?: unknown,
       requestHeaders?: Record<string, string>,
     ): XMLHttpRequest;
 
@@ -96,7 +154,7 @@ declare namespace _ZoteroTypes {
      * @param {Function} onDone Callback to be executed upon request completion
      * @param {String} headers Request HTTP headers
      * @param {String} responseCharset Character set to force on the response
-     * @param {Zotero.CookieSandbox} [cookieSandbox] Cookie sandbox object
+     * @param {unknown} [cookieSandbox] Ignored since Zotero 10
      * @return {XMLHttpRequest} The XMLHttpRequest object if the request was sent, or
      *     false if the browser is offline
      * @deprecated Use {@link Zotero.HTTP.request}
@@ -106,8 +164,8 @@ declare namespace _ZoteroTypes {
       body: string,
       onDone: (xhr: XMLHttpRequest) => void | Promise<void>,
       headers: Record<string, string>,
-      responseCharset: string,
-      cookieSandbox?: Zotero.CookieSandbox,
+      responseCharset?: string,
+      cookieSandbox?: unknown,
     ): XMLHttpRequest;
 
     /**
@@ -116,7 +174,7 @@ declare namespace _ZoteroTypes {
      * @param {String} url URL to request
      * @param {Function} onDone Callback to be executed upon request completion
      * @param {Object} requestHeaders HTTP headers to include with request
-     * @param {Zotero.CookieSandbox} [cookieSandbox] Cookie sandbox object
+     * @param {unknown} [cookieSandbox] Ignored since Zotero 10
      * @return {XMLHttpRequest} The XMLHttpRequest object if the request was sent, or
      *     false if the browser is offline
      * @deprecated Use {@link Zotero.HTTP.request}
@@ -124,8 +182,8 @@ declare namespace _ZoteroTypes {
     doHead(
       url: string | URL,
       onDone: (xhr: XMLHttpRequest) => void | Promise<void>,
-      requestHeaders: Record<string, string>,
-      cookieSandbox?: Zotero.CookieSandbox,
+      requestHeaders?: Record<string, string>,
+      cookieSandbox?: unknown,
     ): XMLHttpRequest;
 
     /**
@@ -168,7 +226,6 @@ declare namespace _ZoteroTypes {
      * @param {Function} processor - Callback to be executed for each document loaded; if function returns
      *     a promise, it's waited for before continuing
      * @param {Object} [options]
-     * @param {Zotero.CookieSandbox} [options.cookieSandbox] - Cookie sandbox object
      * @param {Object} [options.headers] - Headers to include in the request
      * @return {Promise<Array>} - A promise for an array of results from the processor runs
      */
@@ -176,7 +233,6 @@ declare namespace _ZoteroTypes {
       urls: string | string[],
       processor: (doc: Document, responseURL: string) => T | Promise<T>,
       options?: {
-        cookieSandbox?: Zotero.CookieSandbox;
         headers?: Record<string, string>;
       },
     ): Promise<T[]>;

--- a/types/xpcom/mime.d.ts
+++ b/types/xpcom/mime.d.ts
@@ -62,13 +62,9 @@ declare namespace Zotero {
 
     /**
      * @param {String} url
-     * @param {Zotero.CookieSandbox} [cookieSandbox]
      * @return {Promise<[string, boolean]>} Resolves with [mimeType, hasNativeHandler]
      */
-    function getMIMETypeFromURL(
-      url: string,
-      cookieSandbox?: any,
-    ): Promise<[string, boolean]>;
+    function getMIMETypeFromURL(url: string): Promise<[string, boolean]>;
 
     /*
      * Determine if a MIME type can be handled natively

--- a/types/xpcom/pluginAPI/menuManager.d.ts
+++ b/types/xpcom/pluginAPI/menuManager.d.ts
@@ -108,8 +108,13 @@ declare namespace _ZoteroTypes {
     interface LibraryMenuContext extends BaseMenuContext {
       /** Array of selected items */
       items?: Zotero.Item[];
-      /** Collection tree row (for collection menus) */
-      collectionTreeRow?: _ZoteroTypes.CollectionTree;
+      /**
+       * @deprecated Removed in Zotero 10 — reading this property throws.
+       *     Use {@link collectionTreeRows}, which contains the full selection.
+       */
+      collectionTreeRow?: never;
+      /** Selected collection tree rows (full selection, Zotero 10+) */
+      collectionTreeRows?: Zotero.CollectionTreeRow[];
       /** Type of the tab */
       tabType: "library";
       /** Subtype of the tab */

--- a/types/xpcom/server.d.ts
+++ b/types/xpcom/server.d.ts
@@ -45,13 +45,24 @@ declare namespace _ZoteroTypes {
   namespace Server {
     class Endpoint {
       supportedMethods?: string[];
-      supportedDataTypes?: Array<
-        | "application/json"
-        | "application/x-www-form-urlencoded"
-        | "multipart/form-data"
-        | string
-      >;
+      supportedDataTypes?:
+        | Array<
+            | "application/json"
+            | "application/x-www-form-urlencoded"
+            | "multipart/form-data"
+            | string
+          >
+        | "*";
       permitBookmarklet?: boolean;
+
+      /**
+       * Since Zotero 10, requests that look like they come from a browser
+       * (User-Agent starting with `Mozilla/`, or any `Origin` header) are
+       * dropped unless they include a `Zotero-Allowed-Request` header or come
+       * from the connector. Set this to true to explicitly opt into allowing
+       * such requests for this endpoint.
+       */
+      allowRequestsFromUnsafeWebContent?: boolean;
 
       init: initMethodEvent | initMethodPromise;
     }
@@ -59,7 +70,8 @@ declare namespace _ZoteroTypes {
     type initMethodPromise = (options: {
       method: "GET" | "POST";
       pathname: string;
-      query: Record<string, string>;
+      pathParams: Record<string, string>;
+      searchParams: URLSearchParams;
       headers: Record<string, string>;
       data: any;
     }) => MaybePromise<

--- a/types/xpcom/undoHistory.d.ts
+++ b/types/xpcom/undoHistory.d.ts
@@ -1,3 +1,55 @@
+declare namespace _ZoteroTypes {
+  namespace UndoHistory {
+    /**
+     * Fluent message ID for an undo entry's action label. Zotero ships the
+     * `undo-action-*` strings below; plugins can use their own Fluent IDs
+     * after registering them with `Zotero.ftl.addResourceIds()`.
+     */
+    type UndoAction =
+      | "undo-action-edit-metadata"
+      | "undo-action-edit-field"
+      | "undo-action-normalize-attachment-titles"
+      | "undo-action-trash"
+      | "undo-action-restore-items"
+      | "undo-action-trash-collection"
+      | "undo-action-trash-search"
+      | "undo-action-restore-collection"
+      | "undo-action-restore-objects"
+      | "undo-action-add-to-collection"
+      | "undo-action-remove-from-collection"
+      | "undo-action-move-to-collection"
+      | "undo-action-rename-collection"
+      | "undo-action-move-collection"
+      | "undo-action-add-tag"
+      | "undo-action-change-tag"
+      | "undo-action-split-tag"
+      | "undo-action-remove-tag"
+      | "undo-action-remove-tags-from-item"
+      | "undo-action-remove-all-tags"
+      | "undo-action-edit-note"
+      | "undo-action-add-creator"
+      | "undo-action-remove-creator"
+      | "undo-action-edit-creator"
+      | "undo-action-reorder-creator"
+      | "undo-action-change-type"
+      | "undo-action-change-parent-item"
+      | "undo-action-convert-to-standalone"
+      | "undo-action-add-related"
+      | "undo-action-remove-related"
+      | "undo-action-merge-items"
+      | (string & {});
+
+    interface ChangeRecord {
+      objectType: string;
+      id: number;
+      libraryID: number;
+      key: string;
+      fields: Record<string, { old: unknown; new: unknown }>;
+      skipDateModified?: boolean;
+    }
+  }
+}
+
 declare namespace Zotero {
   class UndoHistory {
     /**
@@ -40,7 +92,7 @@ declare namespace Zotero {
      * @param actionArgs Optional Fluent message arguments (e.g. { count: 3 })
      */
     static stageAction(
-      action: string,
+      action: _ZoteroTypes.UndoHistory.UndoAction,
       actionArgs?: Record<string, unknown>,
     ): void;
     /**
@@ -48,14 +100,9 @@ declare namespace Zotero {
      * Must be called inside a DB transaction. Records for the same object
      * are coalesced field-by-field (first-write-wins for old, last-wins for new).
      */
-    static stageChange(changeRecord: {
-      objectType: string;
-      id: number;
-      libraryID: number;
-      key: string;
-      fields: Record<string, { old: unknown; new: unknown }>;
-      skipDateModified?: boolean;
-    }): void;
+    static stageChange(
+      changeRecord: _ZoteroTypes.UndoHistory.ChangeRecord,
+    ): void;
     /**
      * Return the action description for the top of the undo stack.
      */
@@ -71,10 +118,15 @@ declare namespace Zotero {
       actionArgs: Record<string, unknown> | null;
     } | null;
     /**
-     * Return a XUL controller that delegates to native text-editing
-     * controllers when they are active.
+     * Return a XUL controller supporting 'cmd_undo'/'cmd_redo' that
+     * delegates to native text-editing controllers when they are active.
      */
-    static getController(doc: Document): object;
+    static getController(doc: Document): {
+      supportsCommand(cmd: string): boolean;
+      isCommandEnabled(cmd: string): boolean;
+      doCommand(cmd: string): void;
+      onEvent(evt: string): void;
+    };
     /**
      * Return true if a native text editor handles undo (e.g. focused input).
      */

--- a/types/zotero.d.ts
+++ b/types/zotero.d.ts
@@ -162,15 +162,19 @@ declare namespace Zotero {
    * @param {String} uri
    * @param {Object} [options]
    * @param {Function} [options.onLoad] - Function to run once URI is loaded; passed the loaded document
-   * @param {Object} [options.cookieSandbox] - Attach a cookie sandbox to the browser
    * @param {Boolean} [options.allowJavaScript] - Set to false to disable JavaScript
+   * @param {Number} [options.userContextId] - To isolate the viewer's cookies
+   *     into the same jar as a Zotero.HTTP.request or HiddenBrowser using the same ID
+   * @param {String} [options.customUserAgent] - Override the User-Agent for all requests
+   *     from this viewer's browsing context
    */
   function openInViewer(
     uri: string,
     options?: {
       onLoad?: (doc: Document) => void;
-      cookieSandbox?: Zotero.CookieSandbox;
       allowJavaScript?: boolean;
+      userContextId?: number;
+      customUserAgent?: string;
     },
   ): void;
 
@@ -280,15 +284,16 @@ declare namespace Zotero {
   };
 
   /**
-   * Fluent localization instance shared across the application.
+   * Synchronous-mode Fluent Localization instance shared across the
+   * application.
    * Register plugin FTL files with addResourceIds() to make strings
-   * available for undo labels and other global Fluent lookups.
+   * available for undo labels and other global Fluent lookups; remove them
+   * on shutdown with removeResourceIds(). All plugins' strings are
+   * consolidated into a single localization source with proper per-locale
+   * fallback.
    * @since Zotero 10
    */
-  const ftl: {
-    addResourceIds: (resourceIds: string[]) => void;
-    removeResourceIds: (resourceIds: string[]) => void;
-  };
+  const ftl: Localization;
 
   const Intl: {
     strings: {

--- a/types/zoteroPane.d.ts
+++ b/types/zoteroPane.d.ts
@@ -7,22 +7,58 @@ declare namespace _ZoteroTypes {
     [attr: string]: any;
     document: Document & { body: null; head: null };
     collectionsView: CollectionTree | false;
-    itemsView: ItemTree | false;
+    itemsView: CollectionViewItemTree | false;
     itemPane: ItemPane | false;
     progressWindow: Zotero.ProgressWindow | false;
 
     newCollection(parentKey: string): Promise<undefined | Zotero.Collection>;
+    /**
+     * @deprecated Since Zotero 10 the Advanced Search window no longer
+     *     exists; it has moved into the main window.
+     *     Use {@link toggleAdvancedSearchState} instead.
+     */
     openAdvancedSearchWindow(): void;
+    /**
+     * Toggle the in-window Advanced Search pane (Zotero 10+)
+     *
+     * @param {'open' | 'collapsed' | 'closed'} state
+     */
+    toggleAdvancedSearchState(
+      state?: "open" | "collapsed" | "closed",
+    ): Promise<void>;
     updateTagFilter(): Promise<undefined>;
     toggleTagSelector(): void;
     tagSelectorShown(): undefined | boolean;
-    getSelectedLibraryID(): number;
-    getSelectedGroup(): Zotero.Collection;
-    getSelectedGroup(asID: boolean): Zotero.Collection | number;
-    getSelectedSavedSearch(): Zotero.Collection;
-    getSelectedSavedSearch(asID: boolean): Zotero.Collection | number;
-    getSelectedCollection(asID?: false): Zotero.Collection | undefined;
-    getSelectedCollection(asID: true): number | undefined;
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getSelectedLibraryIDs} instead.
+     */
+    getSelectedLibraryID(): never;
+    /**
+     * @return {Integer[]} - libraryIDs of the selected rows, in collections-list order
+     */
+    getSelectedLibraryIDs(): number[];
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Filter {@link getCollectionTreeRows} by `isGroup()` instead.
+     */
+    getSelectedGroup(asID?: boolean): never;
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getSelectedSavedSearches} instead.
+     */
+    getSelectedSavedSearch(asID?: boolean): never;
+    /** Selected saved searches, safe for any selection (Zotero 10+) */
+    getSelectedSavedSearches(asID?: false): Zotero.Search[];
+    getSelectedSavedSearches(asID: true): number[];
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getSelectedCollections} instead.
+     */
+    getSelectedCollection(asID?: boolean): never;
+    /** Selected collections, safe for any selection (Zotero 10+) */
+    getSelectedCollections(asID?: false): Zotero.Collection[];
+    getSelectedCollections(asID: true): number[];
     selectItem(itemID: number, inLibraryRoot?: boolean): undefined | boolean;
     selectItems: (
       itemIDs: Array<number>,
@@ -37,7 +73,15 @@ declare namespace _ZoteroTypes {
     duplicateAndConvertSelectedItem(): Promise<Zotero.Item | boolean>;
     restoreSelectedItems(): Promise<void>;
     updateNoteButtonMenu(): Promise<void>;
-    getCollectionTreeRow(): undefined | CollectionTree;
+    /**
+     * @deprecated Removed in Zotero 10 — throws when called.
+     *     Use {@link getCollectionTreeRows} instead.
+     */
+    getCollectionTreeRow(): never;
+    /**
+     * Selected collection tree rows, in collections-list order (Zotero 10+)
+     */
+    getCollectionTreeRows(): Zotero.CollectionTreeRow[];
     showOriginalItem(): void;
     search(runAdvanced: boolean): Promise<void>;
     sync(): void;


### PR DESCRIPTION
- Removed deprecated CookieSandbox parameter from various functions and replaced with userContextId for cookie isolation.
- Added new methods and properties to support recent features in Zotero 10, including advanced search handling and improved item management.
- Updated item and attachment handling to enforce stricter type checks and error handling.
- Enhanced search functionality with new conditions and improved result handling.
- Deprecated several methods and properties that are no longer relevant in Zotero 10, ensuring cleaner and more maintainable code.
- Improved documentation throughout the types to clarify usage and expectations for new features.